### PR TITLE
chore(package.json): add types export to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
When importing the project, the types were not inserted in the files due to their absence in the exports section.